### PR TITLE
Add NuMicro 8051 ICP programmer

### DIFF
--- a/NuvoICPNewAE.c
+++ b/NuvoICPNewAE.c
@@ -71,6 +71,10 @@ bool NuvoICP_Protocol_Command(void)
     nuvoicp_status_payload_size = NuvoICP_GetParam(NUVO_CMD_GET_DEVICEID, &status_payload[STATUS_DATA_START]);
     break;
 
+  case NUVO_CMD_GET_PID:
+    nuvoicp_status_payload_size = NuvoICP_GetParam(NUVO_CMD_GET_PID, &status_payload[STATUS_DATA_START]);
+    break;
+
   case NUVO_CMD_GET_UID:
     nuvoicp_status_payload_size = NuvoICP_GetParam(NUVO_CMD_GET_UID,  &status_payload[STATUS_DATA_START]);
     break;
@@ -312,6 +316,10 @@ uint16_t NuvoICP_GetParam(uint8_t cmd, uint8_t *buf)
     case NUVO_CMD_GET_UCID:
       N51ICP_read_ucid(buf);
       val_length = 16;
+      break;
+    case NUVO_CMD_GET_PID:
+      value = N51ICP_read_pid();
+      in_val = true;
       break;
   }
   if (in_val)

--- a/NuvoICPNewAE.c
+++ b/NuvoICPNewAE.c
@@ -1,0 +1,339 @@
+#define INCLUDE_FROM_NUVOICP_C 1
+#include "NuvoICPNewAE.h"
+#undef INCLUDE_FROM_NUVOICP_C
+#include "NuvoProgCommon.h"
+#include "n51_icp.h"
+#include <stdint.h>
+#include <string.h>
+
+#define NUVOICP_BUF_SIZE 256
+#define STATUS_DATA_START 3
+// Request payload params start at this index
+#define PDATA_START 0
+
+/* Status of last executed command */
+uint8_t N51_Status;
+
+uint32_t unpack_u32(uint8_t *buf, uint32_t offset)
+{
+  return (buf[offset + 3] << 24) | (buf[offset + 2] << 16) | (buf[offset + 1] << 8) | buf[offset];
+}
+
+bool _check_param_len(uint8_t len)
+{
+  if (udd_g_ctrlreq.req.wLength < len + PDATA_START)
+  {
+    N51_Status = NUVO_ERR_INCORRECT_PARAMS;
+    return false;
+  }
+  N51_Status = NUVO_ERR_OK;
+  return true;
+}
+
+
+bool NuvoICP_Protocol_Command(void)
+{
+  static uint8_t status_payload[32];
+  status_payload[0] = udd_g_ctrlreq.req.wValue & 0xff;
+  static uint16_t nuvoicp_status_payload_size = 0;
+
+  static uint8_t NuvoICP_rambuf[NUVOICP_BUF_SIZE];
+  uint8_t offset;
+
+  switch (status_payload[0])
+  {
+  case NUVO_CMD_WRITE_FLASH:
+    NuvoICP_WriteMemory(NuvoICP_rambuf, &status_payload[STATUS_DATA_START]);
+    nuvoicp_status_payload_size = 2;
+    break;
+
+  case NUVO_CMD_PAGE_ERASE:
+    NuvoICP_Page_Erase(NuvoICP_rambuf);
+    break;
+
+  case NUVO_CMD_MASS_ERASE:
+    NuvoICP_Mass_Erase();
+    break;
+
+  case NUVO_CMD_READ_FLASH:
+    NuvoICP_ReadMemory(NuvoICP_rambuf);
+    break;
+
+  case NUVO_CMD_RESET:
+    NuvoICP_LeaveProgMode();
+    break;
+
+  case NUVO_CMD_CONNECT:
+    NuvoICP_EnterProgMode();
+    break;
+
+  case NUVO_CMD_GET_DEVICEID:
+    nuvoicp_status_payload_size = NuvoICP_GetParam(NUVO_CMD_GET_DEVICEID, &status_payload[STATUS_DATA_START]);
+    break;
+
+  case NUVO_CMD_GET_UID:
+    nuvoicp_status_payload_size = NuvoICP_GetParam(NUVO_CMD_GET_UID,  &status_payload[STATUS_DATA_START]);
+    break;
+
+  case NUVO_CMD_GET_CID:
+    nuvoicp_status_payload_size = NuvoICP_GetParam(NUVO_CMD_GET_CID, &status_payload[STATUS_DATA_START]);
+    break;
+
+  case NUVO_CMD_GET_UCID:
+    nuvoicp_status_payload_size = NuvoICP_GetParam(NUVO_CMD_GET_UCID, &status_payload[STATUS_DATA_START]);
+    break;
+  case NUVO_GET_RAMBUF:
+    offset = (udd_g_ctrlreq.req.wValue >> 8) & 0xff;
+    if ((offset + udd_g_ctrlreq.req.wLength) > NUVOICP_BUF_SIZE)
+    {
+      // nice try!
+      return false;
+    }
+
+    udd_g_ctrlreq.payload = NuvoICP_rambuf + offset;
+    udd_g_ctrlreq.payload_size = udd_g_ctrlreq.req.wLength;
+    return true;
+    break;
+
+  // Write data to intername RAM buffer
+  case NUVO_SET_RAMBUF:
+    N51_Status = NUVO_ERR_OK;
+    offset = (udd_g_ctrlreq.req.wValue >> 8) & 0xff;
+    if ((offset + udd_g_ctrlreq.req.wLength) > NUVOICP_BUF_SIZE)
+    {
+      // nice try!
+      N51_Status = NUVO_ERR_INCORRECT_PARAMS;
+      return false;
+    }
+
+    memcpy(NuvoICP_rambuf + offset, udd_g_ctrlreq.payload,
+           udd_g_ctrlreq.req.wLength);
+    return true;
+    break;
+
+  case NUVO_GET_STATUS:
+    status_payload[1] = N51_Status;
+    status_payload[2] = 0;
+    udd_g_ctrlreq.payload = status_payload;
+    udd_g_ctrlreq.payload_size = nuvoicp_status_payload_size + STATUS_DATA_START;
+    nuvoicp_status_payload_size = 0;
+    return true;
+    break;
+
+  case NUVO_CMD_ENTER_ICP_MODE:
+  {
+    if (!_check_param_len(1)) {
+      return false;
+    }
+    N51ICP_enter_icp_mode(udd_g_ctrlreq.payload[PDATA_START]);
+  } break;
+
+  case NUVO_CMD_EXIT_ICP_MODE:
+    N51_Status = NUVO_ERR_OK;
+    N51ICP_exit_icp_mode();
+    break;
+  
+  case NUVO_CMD_REENTER_ICP:
+    NuvoICP_Reentry();
+    break;
+
+  case NUVO_CMD_REENTRY_GLITCH:
+    N51_Status = NUVO_ERR_OK;
+    NuvoICP_Reentry_glitch();
+    break;
+
+  case NUVO_SET_PROG_TIME:
+    if (!_check_param_len(4)){
+      return false;
+    }
+    N51ICP_set_program_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START));
+    break;
+  
+  case NUVO_SET_PAGE_ERASE_TIME:
+    if (!_check_param_len(4)){
+      return false;
+    }
+    N51ICP_set_page_erase_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START));
+    break;
+
+  default:
+    break;
+  }
+
+  return false;
+}
+
+void NuvoICP_Reentry(void)
+{
+  if (!_check_param_len(12)){
+    return;
+  }
+  uint32_t delay1 = unpack_u32(udd_g_ctrlreq.payload, PDATA_START);
+  uint32_t delay2 = unpack_u32(udd_g_ctrlreq.payload, PDATA_START + 4);
+  uint32_t delay3 = unpack_u32(udd_g_ctrlreq.payload, PDATA_START + 8);
+  N51ICP_reentry(delay1, delay2, delay3);
+}
+
+void NuvoICP_Reentry_glitch(void)
+{
+  if (!_check_param_len(16)){
+    return;
+  }
+  uint32_t delay1 = unpack_u32(udd_g_ctrlreq.payload, PDATA_START);
+  uint32_t delay2 = unpack_u32(udd_g_ctrlreq.payload, PDATA_START + 4);
+  uint32_t delay3 = unpack_u32(udd_g_ctrlreq.payload, PDATA_START + 8);
+  uint32_t delay4 = unpack_u32(udd_g_ctrlreq.payload, PDATA_START + 12);
+
+  N51ICP_reentry_glitch(delay1, delay2, delay3, delay4);
+}
+
+void NuvoICP_EnterProgMode(void)
+{
+  uint8_t res = N51ICP_init(true);
+  if (res < 0) // negative error codes
+  {
+    N51_Status = res * -1;
+  }
+  else if (res == 0)
+  {
+    N51_Status = NUVO_ERR_OK;
+  } else {
+    N51_Status = res;
+  }
+}
+
+void NuvoICP_LeaveProgMode(void)
+{
+  uint8_t leave_reset_high = 0; // default to high_z
+  // parameter is optional
+  if (udd_g_ctrlreq.req.wLength >= 1 + PDATA_START) {
+    leave_reset_high = udd_g_ctrlreq.payload[PDATA_START];
+  }
+  N51ICP_deinit(leave_reset_high);
+  N51_Status = NUVO_ERR_OK;
+}
+
+void NuvoICP_Mass_Erase(void)
+{
+  N51ICP_mass_erase();
+  N51_Status = NUVO_ERR_OK;
+}
+
+// expects an 32-bit address and a 16-bit length
+bool NuvoICP_WriteMemory(uint8_t *buf, uint8_t *status_buf_data)
+{
+  status_buf_data[0] = 0;
+  status_buf_data[1] = 0;
+  if (!_check_param_len(6)){
+    return false;
+  }
+
+  uint32_t Address = (udd_g_ctrlreq.payload[PDATA_START+3] << 24) |
+                      (udd_g_ctrlreq.payload[PDATA_START+2] << 16) |
+                      (udd_g_ctrlreq.payload[PDATA_START+1] << 8) |
+                      (udd_g_ctrlreq.payload[PDATA_START]);
+  uint16_t Length = udd_g_ctrlreq.payload[PDATA_START+4] |
+                    (udd_g_ctrlreq.payload[PDATA_START+5] << 8);
+
+  if (Length > NUVOICP_BUF_SIZE)
+  {
+    Length = NUVOICP_BUF_SIZE;
+  }
+  uint16_t checksum = 0;
+  uint32_t addr_written = N51ICP_write_flash(Address, Length, buf);
+  for (uint16_t i = 0; i < Length; i++)
+  {
+    checksum += buf[i];
+  }
+  // pack them into the status_buf_data
+  status_buf_data[0] = checksum & 0xff;
+  status_buf_data[1] = (checksum >> 8) & 0xff;
+  if (addr_written != Address + Length){
+    N51_Status = NUVO_ERR_WRITE_FAILED;
+    return false;
+  }
+
+  N51_Status = NUVO_ERR_OK;
+  return true;
+}
+
+// expects a 32-bit address
+void NuvoICP_Page_Erase(uint8_t * NuvoICP_rambuf){
+  if (!_check_param_len(4)){
+    return;
+  }
+  uint32_t Address = (udd_g_ctrlreq.payload[PDATA_START+3] << 24) | 
+                      (udd_g_ctrlreq.payload[PDATA_START+2] << 16) | 
+                      (udd_g_ctrlreq.payload[PDATA_START+1] << 8) | 
+                      (udd_g_ctrlreq.payload[PDATA_START]);
+  N51ICP_page_erase(Address);
+}
+
+/**
+ * @brief Get the value of a parameter
+ * 
+ * @param cmd The command to get the value of
+ * @param buf The buffer to store the value in
+ * @returns The length of the value
+*/
+uint16_t NuvoICP_GetParam(uint8_t cmd, uint8_t *buf)
+{
+  N51_Status = NUVO_ERR_OK;
+  uint32_t value = 0;
+  bool in_val = false;
+  uint16_t val_length = 0;
+  switch (cmd)
+  {
+    case NUVO_CMD_GET_DEVICEID:
+      value = N51ICP_read_device_id();
+      in_val = true;
+      break;
+    case NUVO_CMD_GET_UID:
+      N51ICP_read_uid(buf);
+      val_length = 12;
+      break;
+    case NUVO_CMD_GET_CID:
+      value = N51ICP_read_cid();
+      in_val = true;
+      break;
+    case NUVO_CMD_GET_UCID:
+      N51ICP_read_ucid(buf);
+      val_length = 16;
+      break;
+  }
+  if (in_val)
+  {
+    buf[0] = value & 0xff;
+    buf[1] = (value >> 8) & 0xff;
+    buf[2] = (value >> 16) & 0xff;
+    buf[3] = (value >> 24) & 0xff;
+    val_length = 4;
+  }
+
+  N51_Status = NUVO_ERR_OK;
+  return val_length;
+}
+
+void NuvoICP_ReadMemory(uint8_t *buf)
+{
+  if (!_check_param_len(6)){
+    return;
+  }
+  uint32_t Address = (udd_g_ctrlreq.payload[PDATA_START+3] << 24) |
+                      (udd_g_ctrlreq.payload[PDATA_START+2] << 16) |
+                      (udd_g_ctrlreq.payload[PDATA_START+1] << 8) |
+                      (udd_g_ctrlreq.payload[PDATA_START]);
+  uint16_t Length = udd_g_ctrlreq.payload[PDATA_START+4] |
+                    (udd_g_ctrlreq.payload[PDATA_START+5] << 8);
+  if (Length > NUVOICP_BUF_SIZE)
+  {
+    Length = NUVOICP_BUF_SIZE;
+  }
+
+  uint32_t addr_read = N51ICP_read_flash(Address, Length, buf);
+  if (addr_read != Address + Length){
+    N51_Status = NUVO_ERR_READ_FAILED;
+    return;
+  }
+  N51_Status = NUVO_ERR_OK;
+}

--- a/NuvoICPNewAE.c
+++ b/NuvoICPNewAE.c
@@ -156,6 +156,19 @@ bool NuvoICP_Protocol_Command(void)
     N51ICP_set_page_erase_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START));
     break;
 
+  case NUVO_SET_MASS_ERASE_TIME:
+    if (!_check_param_len(4)){
+      return false;
+    }
+    N51ICP_set_mass_erase_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START));
+    break;
+
+  case NUVO_SET_POST_MASS_ERASE_TIME:
+    if (!_check_param_len(4)){
+      return false;
+    }
+    N51ICP_set_post_mass_erase_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START));
+    break;
   default:
     break;
   }

--- a/NuvoICPNewAE.c
+++ b/NuvoICPNewAE.c
@@ -129,7 +129,12 @@ bool NuvoICP_Protocol_Command(void)
     if (!_check_param_len(1)) {
       return false;
     }
-    N51ICP_enter_icp_mode(udd_g_ctrlreq.payload[PDATA_START]);
+    uint32_t ret = N51ICP_enter_icp_mode(udd_g_ctrlreq.payload[PDATA_START]);
+    nuvoicp_status_payload_size = 4;
+    status_payload[STATUS_DATA_START] = ret & 0xff;
+    status_payload[STATUS_DATA_START + 1] = (ret >> 8) & 0xff;
+    status_payload[STATUS_DATA_START + 2] = (ret >> 16) & 0xff;
+    status_payload[STATUS_DATA_START + 3] = (ret >> 24) & 0xff;
   } break;
 
   case NUVO_CMD_EXIT_ICP_MODE:
@@ -147,32 +152,26 @@ bool NuvoICP_Protocol_Command(void)
     break;
 
   case NUVO_SET_PROG_TIME:
-    if (!_check_param_len(4)){
+    if (!_check_param_len(8)){
       return false;
     }
-    N51ICP_set_program_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START));
+    N51ICP_set_program_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START), unpack_u32(udd_g_ctrlreq.payload, PDATA_START+4));
     break;
   
   case NUVO_SET_PAGE_ERASE_TIME:
-    if (!_check_param_len(4)){
+    if (!_check_param_len(8)){
       return false;
     }
-    N51ICP_set_page_erase_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START));
+    N51ICP_set_page_erase_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START), unpack_u32(udd_g_ctrlreq.payload, PDATA_START+4));
     break;
 
   case NUVO_SET_MASS_ERASE_TIME:
-    if (!_check_param_len(4)){
+    if (!_check_param_len(8)){
       return false;
     }
-    N51ICP_set_mass_erase_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START));
+    N51ICP_set_mass_erase_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START), unpack_u32(udd_g_ctrlreq.payload, PDATA_START+4));
     break;
 
-  case NUVO_SET_POST_MASS_ERASE_TIME:
-    if (!_check_param_len(4)){
-      return false;
-    }
-    N51ICP_set_post_mass_erase_time(unpack_u32(udd_g_ctrlreq.payload, PDATA_START));
-    break;
   default:
     break;
   }
@@ -206,7 +205,7 @@ void NuvoICP_Reentry_glitch(void)
 
 void NuvoICP_EnterProgMode(void)
 {
-  uint8_t res = N51ICP_init(true);
+  uint8_t res = N51ICP_init();
   if (res < 0) // negative error codes
   {
     N51_Status = res * -1;

--- a/NuvoICPNewAE.h
+++ b/NuvoICPNewAE.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <asf.h>
+
+bool NuvoICP_Protocol_Command(void);
+		#if defined(INCLUDE_FROM_NUVOICP_C)
+			void NuvoICP_Reentry(void);
+			void NuvoICP_Reentry_glitch(void);
+            static void NuvoICP_EnterProgMode(void);
+			static void NuvoICP_LeaveProgMode(void);
+			static uint16_t NuvoICP_GetParam(uint8_t cmd, uint8_t *buf);
+			static void NuvoICP_UpdateConfig(void); 			
+			static void NuvoICP_Mass_Erase(void);
+			static bool NuvoICP_WriteMemory(uint8_t * buf, uint8_t * status_payload);
+			static void NuvoICP_ReadMemory(uint8_t * buf);
+			static void NuvoICP_Page_Erase(uint8_t * buf);
+		#endif

--- a/NuvoICPNewAE.h
+++ b/NuvoICPNewAE.h
@@ -9,7 +9,6 @@ bool NuvoICP_Protocol_Command(void);
             static void NuvoICP_EnterProgMode(void);
 			static void NuvoICP_LeaveProgMode(void);
 			static uint16_t NuvoICP_GetParam(uint8_t cmd, uint8_t *buf);
-			static void NuvoICP_UpdateConfig(void); 			
 			static void NuvoICP_Mass_Erase(void);
 			static bool NuvoICP_WriteMemory(uint8_t * buf, uint8_t * status_payload);
 			static void NuvoICP_ReadMemory(uint8_t * buf);

--- a/NuvoProgCommon.h
+++ b/NuvoProgCommon.h
@@ -1,0 +1,111 @@
+#pragma once
+/**COMMANDS**/
+// Standard commands
+// Write flash
+
+// Enter programming mode
+#define NUVO_CMD_CONNECT 0xae
+// Get Device ID
+#define NUVO_CMD_GET_DEVICEID 0xb1
+// Write flash
+#define NUVO_CMD_PAGE_ERASE 0xD5
+// Exit programming mode
+#define NUVO_CMD_RESET 0xad
+
+// ICP Specific
+// Read flash
+#define NUVO_CMD_READ_FLASH 0xa5
+// Get Unique ID
+#define NUVO_CMD_GET_UID 0xb2
+// Get Company ID
+#define NUVO_CMD_GET_CID 0xb3
+// Get Unique Company ID
+#define NUVO_CMD_GET_UCID 0xb4
+// Mass erase
+#define NUVO_CMD_MASS_ERASE 0xD6
+// Puts the target into ICP mode, but doesn't initialize the PGM.
+#define NUVO_CMD_ENTER_ICP_MODE 0xe7
+// Takes the target out of ICP mode, but doesn't deinitialize the PGM.
+#define NUVO_CMD_EXIT_ICP_MODE 0xe8
+// Takes chip out of and then puts it back into ICP mode
+#define NUVO_CMD_REENTER_ICP 0xe9
+// For getting the configuration bytes to read at consistent times during an ICP reentry.
+#define NUVO_CMD_REENTRY_GLITCH 0xea
+// Release the pins only
+#define NUVO_CMD_DEINIT_PGM_ONLY 0xeb
+// Write to flash
+#define NUVO_CMD_WRITE_FLASH 0xed
+// Set the programming time between bytes
+#define NUVO_SET_PROG_TIME 0xec
+// Set the erase time for a page
+#define NUVO_SET_PAGE_ERASE_TIME 0xee
+
+// ChipWhisperer specific
+#define NUVO_GET_RAMBUF 0xe4
+#define NUVO_SET_RAMBUF 0xe5
+#define NUVO_GET_STATUS 0xe6
+
+#define NUVO_ERR_OK 0
+#define NUVO_ERR_FAILED 1
+#define NUVO_ERR_INCORRECT_PARAMS 2
+#define NUVO_ERR_COLLISION 3
+#define NUVO_ERR_TIMEOUT 4
+#define NUVO_ERR_WRITE_FAILED 5
+#define NUVO_ERR_READ_FAILED 6
+
+// page size
+#define NU51_PAGE_SIZE 128
+#define NU51_PAGE_MASK 0xFF80
+
+
+// // ** ISP commands, Not used by ICP **
+// #define NUVO_CMD_GET_BANDGAP 0xb5
+// #define NUVO_CMD_SYNC_PACKNO 0xa4
+// #define NUVO_CMD_UPDATE_APROM 0xa0
+// #define NUVO_CMD_RUN_APROM 0xab
+// #define NUVO_CMD_RUN_LDROM 0xac    
+// #define NUVO_CMD_RESEND_PACKET 0xFF
+// #define NUVO_CMD_GET_FWVER 0xa6
+// #define NUVO_CMD_ERASE_ALL 0xa3 // This erases just the APROM instead of doing a mass erase
+// #define NUVO_CMD_GET_FLASHMODE 0xCA
+// #define NUVO_CMD_UPDATE_CONFIG 0xa1
+// #define NUVO_CMD_READ_CONFIG 0xa2
+
+// // ** Unsupported by N76E003 **
+// // Dataflash commands (when a chip has the ability to deliniate between data and program flash)
+// #define NUVO_CMD_UPDATE_DATAFLASH 0xC3
+// // SPI flash commands
+// #define NUVO_CMD_ERASE_SPIFLASH 0xD0
+// #define NUVO_CMD_UPDATE_SPIFLASH 0xD1
+// // CAN commands
+// #define NUVO_CAN_CMD_READ_CONFIG 0xA2000000
+// #define NUVO_CAN_CMD_RUN_APROM 0xAB000000
+// #define NUVO_CAN_CMD_GET_DEVICEID 0xB1000000
+
+// // Deprecated, no ISP programmer uses these
+// #define NUVO_CMD_READ_CHECKSUM 0xC8
+// #define NUVO_CMD_WRITE_CHECKSUM 0xC9
+// #define NUVO_CMD_SET_INTERFACE 0xBA
+// // The modes returned by CMD_GET_FLASHMODE
+// #define NUVO_APMODE 1
+// #define NUVO_LDMODE 2
+
+// // ISP packet constants
+// #define NUVO_PKT_CMD_START 0
+// #define NUVO_PKT_CMD_SIZE 4
+// #define NUVO_PKT_SEQ_START 4
+// #define NUVO_PKT_SEQ_SIZE 4
+// #define NUVO_PKT_HEADER_END 8
+
+// #define NUVO_PACKSIZE 64
+
+// #define NUVO_INITIAL_UPDATE_PKT_START 16 // PKT_HEADER_END + 8 bytes for addr and len
+// #define NUVO_INITIAL_UPDATE_PKT_SIZE 48
+
+// #define NUVO_SEQ_UPDATE_PKT_START PKT_HEADER_END
+// #define NUVO_SEQ_UPDATE_PKT_SIZE 56
+
+// #define NUVO_DUMP_PKT_CHECKSUM_START PKT_HEADER_END
+// #define NUVO_DUMP_PKT_CHECKSUM_SIZE 0       // disabled for now
+// #define NUVO_DUMP_DATA_START PKT_HEADER_END //(DUMP_PKT_CHECKSUM_START + DUMP_PKT_CHECKSUM_SIZE)
+// #define NUVO_DUMP_DATA_SIZE 56              //(PACKSIZE - DUMP_DATA_START)

--- a/NuvoProgCommon.h
+++ b/NuvoProgCommon.h
@@ -39,8 +39,6 @@
 #define NUVO_SET_PAGE_ERASE_TIME 0xee
 // Set the mass erase time.
 #define NUVO_SET_MASS_ERASE_TIME 0xef
-// Set the post mass erase time.
-#define NUVO_SET_POST_MASS_ERASE_TIME 0xe3
 // Get the PID of the chip
 #define NUVO_CMD_GET_PID 0xeb
 

--- a/NuvoProgCommon.h
+++ b/NuvoProgCommon.h
@@ -31,14 +31,16 @@
 #define NUVO_CMD_REENTER_ICP 0xe9
 // For getting the configuration bytes to read at consistent times during an ICP reentry.
 #define NUVO_CMD_REENTRY_GLITCH 0xea
-// Release the pins only
-#define NUVO_CMD_DEINIT_PGM_ONLY 0xeb
 // Write to flash
 #define NUVO_CMD_WRITE_FLASH 0xed
 // Set the programming time between bytes
 #define NUVO_SET_PROG_TIME 0xec
 // Set the erase time for a page
 #define NUVO_SET_PAGE_ERASE_TIME 0xee
+// Set the mass erase time.
+#define NUVO_SET_MASS_ERASE_TIME 0xef
+// Set the post mass erase time.
+#define NUVO_SET_POST_MASS_ERASE_TIME 0xe3
 
 // ChipWhisperer specific
 #define NUVO_GET_RAMBUF 0xe4

--- a/NuvoProgCommon.h
+++ b/NuvoProgCommon.h
@@ -41,6 +41,8 @@
 #define NUVO_SET_MASS_ERASE_TIME 0xef
 // Set the post mass erase time.
 #define NUVO_SET_POST_MASS_ERASE_TIME 0xe3
+// Get the PID of the chip
+#define NUVO_CMD_GET_PID 0xeb
 
 // ChipWhisperer specific
 #define NUVO_GET_RAMBUF 0xe4

--- a/n51_icp.c
+++ b/n51_icp.c
@@ -1,5 +1,5 @@
 /*
- * nuvo51icp, an ICP flasher for the Nuvoton N76E003
+ * nuvo51icp, an ICP flasher for the Nuvoton NuMicro 8051 line of chips
  * https://github.com/steve-m/N76E003-playground
  *
  * Copyright (c) 2021 Steve Markgraf <steve@steve-m.de>
@@ -36,11 +36,24 @@
 #ifndef DEFAULT_BIT_DELAY
 #include "delay.h"
 #endif
+
+#define DEFAULT_PROGRAM_TIME 25
+#define DEFAULT_PROGRAM_HOLD_TIME 5
+#define DEFAULT_PAGE_ERASE_TIME 6000
+#define DEFAULT_PAGE_ERASE_HOLD_TIME 100
+#define DEFAULT_MASS_ERASE_TIME 65000
+#define DEFAULT_MASS_ERASE_HOLD_TIME 1000
+#define N76E616_PROGRAM_TIME 40
+#define N76E616_PAGE_ERASE_TIME 40000
+
 // These are MCU dependent (default for N76E003)
-static uint32_t program_time = 25;
-static uint32_t page_erase_time = 6000;
-static uint32_t mass_erase_time = 65000;
-static uint32_t post_mass_erase_time = 1000;
+static uint32_t program_time = DEFAULT_PROGRAM_TIME;
+static uint32_t program_hold_time = DEFAULT_PROGRAM_HOLD_TIME;
+static uint32_t page_erase_time = DEFAULT_PAGE_ERASE_TIME;
+static uint32_t page_erase_hold_time = DEFAULT_PAGE_ERASE_HOLD_TIME;
+static uint32_t mass_erase_time = DEFAULT_MASS_ERASE_TIME;
+static uint32_t mass_erase_hold_time = DEFAULT_MASS_ERASE_HOLD_TIME;
+
 #define ENTRY_BIT_DELAY 60
 
 // ICP Commands
@@ -108,7 +121,7 @@ void N51ICP_send_exit_bits(){
 	N51ICP_bitsend(EXIT_BITS, 24, ENTRY_BIT_DELAY);
 }
 
-int N51ICP_init(uint8_t do_reset)
+int N51ICP_init()
 {
 	int rc;
 	if (!N51PGM_is_init()) {
@@ -119,11 +132,23 @@ int N51ICP_init(uint8_t do_reset)
 			return -1;
 		}
 	}
-	N51ICP_enter_icp_mode(do_reset);
 	return 0;
 }
 
-void N51ICP_enter_icp_mode(uint8_t do_reset) {
+uint32_t post_entry_set_times() {
+	uint32_t devid = N51ICP_read_device_id();
+	// N76E616
+	if (devid >> 8 == 0x2f){
+		page_erase_time = N76E616_PAGE_ERASE_TIME;
+		program_time = N76E616_PROGRAM_TIME;
+	} else {
+		page_erase_time = DEFAULT_PAGE_ERASE_TIME;
+		program_time = DEFAULT_PROGRAM_TIME;
+	}
+	return devid;
+}
+
+uint32_t N51ICP_enter_icp_mode(uint8_t do_reset) {
 	if (do_reset) {
 		send_reset_seq(ICP_RESET_SEQ, 24);
 		N51PGM_set_rst(0);
@@ -137,6 +162,7 @@ void N51ICP_enter_icp_mode(uint8_t do_reset) {
 	USLEEP(100);
 	N51ICP_send_entry_bits();
 	USLEEP(10);
+	return post_entry_set_times();
 }
 
 void N51ICP_reentry(uint32_t delay1, uint32_t delay2, uint32_t delay3) {
@@ -149,6 +175,7 @@ void N51ICP_reentry(uint32_t delay1, uint32_t delay2, uint32_t delay3) {
 	USLEEP(delay2);
 	N51ICP_send_entry_bits();
 	USLEEP(delay3);
+	post_entry_set_times();
 }
 
 void N51ICP_fullexit_entry_glitch(uint32_t delay1, uint32_t delay2, uint32_t delay3){
@@ -187,13 +214,12 @@ void N51ICP_reentry_glitch(uint32_t delay1, uint32_t delay2, uint32_t delay_afte
 	USLEEP(delay2);
 	N51ICP_send_entry_bits();
 	USLEEP(10);
+	// not setting the times since there's no target board for the N76E616
+	// post_entry_set_times();
 }
 
 void N51ICP_deinit(uint8_t leave_reset_high)
 {
-	if (N51PGM_is_init()){
-		N51ICP_exit_icp_mode();
-	}
 	N51PGM_deinit(leave_reset_high);
 }
 
@@ -312,9 +338,8 @@ uint32_t N51ICP_write_flash(uint32_t addr, uint32_t len, uint8_t *data)
 		return 0;
 	}
 	N51ICP_send_command(ICP_CMD_WRITE_FLASH, addr);
-	int delay1 = program_time;
 	for (uint32_t i = 0; i < len; i++) {
-		N51ICP_write_byte(data[i], i == (len-1), delay1, 5);
+		N51ICP_write_byte(data[i], i == (len-1), program_time, program_hold_time);
 	}
 
 	return addr + len;
@@ -323,33 +348,31 @@ uint32_t N51ICP_write_flash(uint32_t addr, uint32_t len, uint8_t *data)
 void N51ICP_mass_erase(void)
 {
 	N51ICP_send_command(ICP_CMD_MASS_ERASE, 0x3A5A5);
-	N51ICP_write_byte(0xff, 1, mass_erase_time, post_mass_erase_time);
+	N51ICP_write_byte(0xff, 1, mass_erase_time, mass_erase_hold_time);
 }
 
 void N51ICP_page_erase(uint32_t addr)
 {
 	N51ICP_send_command(ICP_CMD_PAGE_ERASE, addr);
-	N51ICP_write_byte(0xff, 1, page_erase_time, 100);
+	N51ICP_write_byte(0xff, 1, page_erase_time, page_erase_hold_time);
 }
 
-void N51ICP_set_program_time(uint32_t time_us)
+void N51ICP_set_program_time(uint32_t delay_us, uint32_t hold_us)
 {
-	program_time = time_us;
+	program_time = delay_us;
+	program_hold_time = hold_us;
 }
 
-void N51ICP_set_page_erase_time(uint32_t time_us)
+void N51ICP_set_page_erase_time(uint32_t delay_us, uint32_t hold_us)
 {
-	page_erase_time = time_us;
+	page_erase_time = delay_us;
+	page_erase_hold_time = hold_us;
 }
 
-void N51ICP_set_mass_erase_time(uint32_t time_us)
+void N51ICP_set_mass_erase_time(uint32_t delay_us, uint32_t hold_us)
 {
-	mass_erase_time = time_us;
-}
-
-void N51ICP_set_post_mass_erase_time(uint32_t time_us)
-{
-	post_mass_erase_time = time_us;
+	mass_erase_time = delay_us;
+	mass_erase_hold_time = hold_us;
 }
 
 void N51ICP_outputf(const char *s, ...)

--- a/n51_icp.c
+++ b/n51_icp.c
@@ -1,0 +1,362 @@
+/*
+ * nuvo51icp, an ICP flasher for the Nuvoton N76E003
+ * https://github.com/steve-m/N76E003-playground
+ *
+ * Copyright (c) 2021 Steve Markgraf <steve@steve-m.de>
+ * Copyright (c) 2023-2024 Nikita Lita
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// CW specific
+#define DEFAULT_BIT_DELAY 2 
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include "n51_icp.h"
+#include "n51_pgm.h"
+#ifndef DEFAULT_BIT_DELAY
+#include "delay.h"
+#endif
+// These are MCU dependent (default for N76E003)
+static uint32_t program_time = 20;
+static uint32_t page_erase_time = 6000;
+
+#define ENTRY_BIT_DELAY 60
+
+// ICP Commands
+#define ICP_CMD_READ_UID		0x04
+#define ICP_CMD_READ_CID		0x0b
+#define ICP_CMD_READ_DEVICE_ID	0x0c
+#define ICP_CMD_READ_FLASH		0x00
+#define ICP_CMD_WRITE_FLASH		0x21
+#define ICP_CMD_MASS_ERASE		0x26
+#define ICP_CMD_PAGE_ERASE		0x22
+
+// ICP Entry sequence
+#define ENTRY_BITS    0x5aa503
+
+// ICP Reset sequence: ICP toggles RST pin according to this bit sequence
+#define ICP_RESET_SEQ 0x9e1cb6
+
+// Alternative Reset sequence earlier nulink firmware revisions used
+#define ALT_RESET_SEQ 0xAE1CB6
+
+// ICP Exit sequence
+#define EXIT_BITS     0xF78F0
+
+#ifndef SUPPORT_OTHER_CHIPS
+#define SUPPORT_OTHER_CHIPS 1
+#endif
+
+// to avoid overhead from calling usleep() for 0 us
+#define USLEEP(x) if (x > 0) N51PGM_usleep(x)
+
+#ifdef _DEBUG
+#define DEBUG_PRINT(...) N51ICP_outputf(__VA_ARGS__)
+#else
+#define DEBUG_PRINT(...)
+#endif
+
+
+static void N51ICP_bitsend(uint32_t data, int len, uint32_t udelay)
+{
+	N51PGM_dat_dir(1);
+	int i = len;
+	while (i--){
+			N51PGM_set_dat((data >> i) & 1);
+			USLEEP(udelay);
+			N51PGM_set_clk(1);
+			USLEEP(udelay);
+			N51PGM_set_clk(0);
+	}
+}
+
+static void N51ICP_send_command(uint8_t cmd, uint32_t dat)
+{
+	N51ICP_bitsend((dat << 6) | cmd, 24, DEFAULT_BIT_DELAY);
+}
+
+int send_reset_seq(uint32_t reset_seq, int len){
+	for (int i = 0; i < len + 1; i++) {
+		N51PGM_set_rst((reset_seq >> (len - i)) & 1);
+		USLEEP(10000);
+	}
+	return 0;
+}
+
+void N51ICP_send_entry_bits() {
+	N51ICP_bitsend(ENTRY_BITS, 24, ENTRY_BIT_DELAY);
+}
+
+void N51ICP_send_exit_bits(){
+	N51ICP_bitsend(EXIT_BITS, 24, ENTRY_BIT_DELAY);
+}
+
+int N51ICP_init(uint8_t do_reset)
+{
+	int rc;
+	if (!N51PGM_is_init()) {
+		rc = N51PGM_init();
+		if (rc < 0) {
+			return rc;
+		} else if (rc != 0){
+			return -1;
+		}
+	}
+	N51ICP_enter_icp_mode(do_reset);
+#if !SUPPORT_OTHER_CHIPS
+	uint32_t dev_id = N51ICP_read_device_id();
+	if (dev_id >> 8 == 0x2F){
+		DEBUG_PRINT("Device ID mismatch: %x\n", dev_id);
+		return -1;
+	}
+#endif
+	return 0;
+}
+
+void N51ICP_enter_icp_mode(uint8_t do_reset) {
+	if (do_reset) {
+		send_reset_seq(ICP_RESET_SEQ, 24);
+		N51PGM_set_rst(0);
+	} else {
+		N51PGM_set_rst(1);
+		USLEEP(5000);
+		N51PGM_set_rst(0);
+		USLEEP(1000);
+	}
+	USLEEP(100);
+	N51ICP_send_entry_bits();
+	USLEEP(10);
+}
+
+void N51ICP_reentry(uint32_t delay1, uint32_t delay2, uint32_t delay3) {
+	USLEEP(10);
+	if (delay1 > 0) {
+		N51PGM_set_rst(1);
+		USLEEP(delay1);
+	}
+	N51PGM_set_rst(0);
+	USLEEP(delay2);
+	N51ICP_send_entry_bits();
+	USLEEP(delay3);
+}
+
+void N51ICP_fullexit_entry_glitch(uint32_t delay1, uint32_t delay2, uint32_t delay3){
+	N51ICP_exit_icp_mode();
+}
+
+void N51ICP_reentry_glitch(uint32_t delay1, uint32_t delay2, uint32_t delay_after_trigger_high, uint32_t delay_before_trigger_low){
+	USLEEP(200);
+	// this bit here it to ensure that the config bytes are read at the correct time (right next to the reset high)
+	N51PGM_set_rst(1);
+	USLEEP(delay1);
+	N51PGM_set_rst(0);
+	USLEEP(delay2);
+
+	//now we do a the full reentry, set the trigger
+	N51PGM_set_trigger(1);
+	USLEEP(delay_after_trigger_high);
+	N51PGM_set_rst(1);
+
+	// by default, we sleep for 280us, the length of the config load
+	if (delay_before_trigger_low == 0) {
+		delay_before_trigger_low = 280;
+	}
+
+	if (delay_before_trigger_low > delay1){
+		USLEEP(delay1);
+		N51PGM_set_rst(0);
+		USLEEP(delay_before_trigger_low - delay1);
+		N51PGM_set_trigger(0);
+	} else {
+		USLEEP(delay_before_trigger_low);
+		N51PGM_set_trigger(0);
+		USLEEP(delay1 - delay_before_trigger_low);
+		N51PGM_set_rst(0);
+	}
+	USLEEP(delay2);
+	N51ICP_send_entry_bits();
+	USLEEP(10);
+}
+
+void N51ICP_deinit(uint8_t leave_reset_high)
+{
+	if (N51PGM_is_init()){
+		N51ICP_exit_icp_mode();
+	}
+	N51PGM_deinit(leave_reset_high);
+}
+
+
+void N51ICP_exit_icp_mode(void)
+{
+	N51PGM_set_rst(1);
+	USLEEP(5000);
+	N51PGM_set_rst(0);
+	USLEEP(10000);
+	N51ICP_send_exit_bits();
+	USLEEP(500);
+	N51PGM_set_rst(1);
+}
+
+
+static uint8_t N51ICP_read_byte(int end)
+{
+	N51PGM_dat_dir(0);
+	USLEEP(DEFAULT_BIT_DELAY);
+	uint8_t data = 0;
+	int i = 8;
+
+	while (i--) {
+		USLEEP(DEFAULT_BIT_DELAY);
+		int state = N51PGM_get_dat();
+		N51PGM_set_clk(1);
+		USLEEP(DEFAULT_BIT_DELAY);
+		N51PGM_set_clk(0);
+		data |= (state << i);
+	}
+
+	N51PGM_dat_dir(1);
+	USLEEP(DEFAULT_BIT_DELAY);
+	N51PGM_set_dat(end);
+	USLEEP(DEFAULT_BIT_DELAY);
+	N51PGM_set_clk(1);
+	USLEEP(DEFAULT_BIT_DELAY);
+	N51PGM_set_clk(0);
+	USLEEP(DEFAULT_BIT_DELAY);
+	N51PGM_set_dat(0);
+
+	return data;
+}
+
+static void N51ICP_write_byte(uint8_t data, uint8_t end, uint32_t delay1, uint32_t delay2)
+{
+	N51ICP_bitsend(data, 8, DEFAULT_BIT_DELAY);
+
+	N51PGM_set_dat(end);
+	USLEEP(delay1);
+	N51PGM_set_clk(1);
+	USLEEP(delay2);
+	N51PGM_set_dat(0);
+	N51PGM_set_clk(0);
+}
+
+uint32_t N51ICP_read_device_id(void)
+{
+	N51ICP_send_command(ICP_CMD_READ_DEVICE_ID, 0);
+
+	uint8_t devid[2];
+	devid[0] = N51ICP_read_byte(0);
+	devid[1] = N51ICP_read_byte(1);
+
+	return (devid[1] << 8) | devid[0];
+}
+
+uint32_t N51ICP_read_pid(void){
+	N51ICP_send_command(ICP_CMD_READ_DEVICE_ID, 2);
+	uint8_t pid[2];
+	pid[0] = N51ICP_read_byte(0);
+	pid[1] = N51ICP_read_byte(1);
+	return (pid[1] << 8) | pid[0];
+}
+
+uint8_t N51ICP_read_cid(void)
+{
+	N51ICP_send_command(ICP_CMD_READ_CID, 0);
+	return N51ICP_read_byte(1);
+}
+
+void N51ICP_read_uid(uint8_t * buf)
+{
+
+	for (uint8_t  i = 0; i < 12; i++) {
+		N51ICP_send_command(ICP_CMD_READ_UID, i);
+		buf[i] = N51ICP_read_byte(1);
+	}
+}
+
+void N51ICP_read_ucid(uint8_t * buf)
+{
+	for (uint8_t i = 0; i < 16; i++) {
+		N51ICP_send_command(ICP_CMD_READ_UID, i + 0x20);
+		buf[i] = N51ICP_read_byte(1);
+	}
+}
+
+uint32_t N51ICP_read_flash(uint32_t addr, uint32_t len, uint8_t *data)
+{
+	if (len == 0) {
+		return 0;
+	}
+	N51ICP_send_command(ICP_CMD_READ_FLASH, addr);
+
+	for (uint32_t i = 0; i < len; i++){
+		data[i] = N51ICP_read_byte(i == (len-1));
+	}
+	return addr + len;
+}
+
+uint32_t N51ICP_write_flash(uint32_t addr, uint32_t len, uint8_t *data)
+{
+	if (len == 0) {
+		return 0;
+	}
+	N51ICP_send_command(ICP_CMD_WRITE_FLASH, addr);
+	int delay1 = program_time;
+	for (uint32_t i = 0; i < len; i++) {
+		N51ICP_write_byte(data[i], i == (len-1), delay1, 5);
+	}
+
+	return addr + len;
+}
+
+void N51ICP_mass_erase(void)
+{
+	N51ICP_send_command(ICP_CMD_MASS_ERASE, 0x3A5A5);
+	N51ICP_write_byte(0xff, 1, 65000, 500);
+}
+
+void N51ICP_page_erase(uint32_t addr)
+{
+	N51ICP_send_command(ICP_CMD_PAGE_ERASE, addr);
+	N51ICP_write_byte(0xff, 1, page_erase_time, 100);
+}
+
+void N51ICP_set_program_time(uint32_t time)
+{
+	program_time = time;
+}
+
+void N51ICP_set_page_erase_time(uint32_t time)
+{
+	page_erase_time = time;
+}
+
+void N51ICP_outputf(const char *s, ...)
+{
+  char buf[160];
+  va_list ap;
+  va_start(ap, s);
+  vsnprintf(buf, 160, s, ap);
+  va_end(ap);
+  N51PGM_print(buf);
+}

--- a/n51_icp.h
+++ b/n51_icp.h
@@ -1,0 +1,156 @@
+/*
+ * nuvo51icp, an ICP flasher for the Nuvoton N76E003
+ * https://github.com/steve-m/N76E003-playground
+ *
+ * Copyright (c) 2021 Steve Markgraf <steve@steve-m.de>
+ * Copyright (c) 2023-2024 Nikita Lita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***
+ * @brief     Initializes the PGM interface and enters the target chip into ICP mode.
+ * @param[in] do_reset If set, the reset sequence will be sent when performing ICP entry (recommended to set this to 1).
+*/
+int N51ICP_init(uint8_t do_reset);
+
+/**
+ * @brief      Deinitializes the PGM interface and exits the target chip from ICP mode.
+ * 
+ * @param[in] leave_reset_high  If set, the reset pin will not be released and will be left high after deinitializing the PGM interface.
+*/
+void N51ICP_deinit(uint8_t leave_reset_high);
+
+/**
+ * Read Device ID (i.e. the chip identifier)
+*/
+uint32_t N51ICP_read_device_id(void);
+/**
+ * Read Product ID
+*/
+uint32_t N51ICP_read_pid(void);
+/**
+ * Read Customer ID
+*/
+uint8_t N51ICP_read_cid(void);
+/**
+ * Read User ID
+*/
+void N51ICP_read_uid(uint8_t * buf);
+/**
+ * Read User Configuration ID
+*/
+void N51ICP_read_ucid(uint8_t * buf);
+/**
+ * Read Flash
+*/
+uint32_t N51ICP_read_flash(uint32_t addr, uint32_t len, uint8_t *data);
+/**
+ * Write Flash
+*/
+uint32_t N51ICP_write_flash(uint32_t addr, uint32_t len, uint8_t *data);
+/**
+ * Mass Erase
+*/
+void N51ICP_mass_erase(void);
+/**
+ * Page Erase
+*/
+void N51ICP_page_erase(uint32_t addr);
+/**
+ * @brief      Output formatted string to the console, using the host device's implementation of print.
+ * 
+ * @param[in]  fmt   The format string
+ * @param[in]  ...   The arguments to be formatted
+*/
+void N51ICP_outputf(const char *fmt, ...);
+
+/***
+ * @brief     Set the program time for the N76E003.
+ * 
+ * This is the time that `N51ICP_write_flash()` will wait between bytes while writing to flash
+ * (default: 20us)
+ * @param time The time in microseconds
+ */
+void N51ICP_set_program_time(uint32_t time_us);
+
+/***
+ * @brief     Set the page erase time for the N76E003.
+ * 
+ * This is the time that `N51ICP_page_erase()` will wait between pages while erasing flash
+ * (default: 6000us)
+ * 
+ * @param time The time in microseconds
+*/
+void N51ICP_set_page_erase_time(uint32_t time_us);
+
+/**
+ * @brief      Puts the target chip into ICP mode.
+ * 
+ * @param do_reset If set, the reset sequence will be sent when performing ICP entry (recommended to set this to 1).
+*/
+void N51ICP_enter_icp_mode(uint8_t do_reset);
+
+/**
+ * @brief      Takes the target chip out of ICP mode.
+*/
+void N51ICP_exit_icp_mode(void);
+
+/**
+ * @brief      Re-enters the target chip into ICP mode.
+ * 
+ * @param delay1  Delay after reset is set to high (Recommended: 5000)
+ * @param delay2  Delay after reset is set to low (Recommended: 1000)
+ * @param delay3  Delay after the entry bits are sent on the data line (Recommended: 10)
+*/
+void N51ICP_reentry(uint32_t delay1, uint32_t delay2, uint32_t delay3);
+
+/**
+ * Sends the ICP entry bits on the DAT line to the target chip.
+*/
+void N51ICP_send_entry_bits();
+/**
+ * Sends the ICP exit bits on the DAT line to the target chip.
+*/
+void N51ICP_send_exit_bits();
+
+/**
+ * @brief      ICP reentry glitching
+ * 
+ * @details    This function is for getting the configuration bytes to read at consistent times during an ICP reentry.
+ *             Every time reset is set high, the configuration bytes are read, but the timing of the reset high is not consistent 
+ *             unless an additional reset 1,0 is performed first. When this is done, the configuration bytes are consistently read at about 2us after the reset high.
+ *             This is primarily for capturing the configuration byte load process.
+ * 
+ * @param[in]  delay1  Delay after reset is set to high
+ * @param[in]  delay2  Delay after reset is set to low
+ * @param[in]  delay_after_trigger_high  Delay after setting trigger pin high (for triggering a capture device), before setting reset high 
+ * @param[in]  delay_before_trigger_low  Delay after setting reset high, before setting trigger pin low
+*/
+void N51ICP_reentry_glitch(uint32_t delay1, uint32_t delay2, uint32_t delay_after_trigger_high, uint32_t delay_before_trigger_low);
+
+#ifdef __cplusplus
+}
+#endif

--- a/n51_icp.h
+++ b/n51_icp.h
@@ -1,5 +1,5 @@
 /*
- * nuvo51icp, an ICP flasher for the Nuvoton N76E003
+ * nuvo51icp, an ICP flasher for the Nuvoton NuMicro 8051 line of chips
  * https://github.com/steve-m/N76E003-playground
  *
  * Copyright (c) 2021 Steve Markgraf <steve@steve-m.de>
@@ -31,13 +31,14 @@ extern "C" {
 #endif
 
 /***
- * @brief     Initializes the PGM interface and enters the target chip into ICP mode.
+ * @brief     Initializes the PGM interface.
  * @param[in] do_reset If set, the reset sequence will be sent when performing ICP entry (recommended to set this to 1).
+ * @return    0 on success, any other value on failure
 */
-int N51ICP_init(uint8_t do_reset);
+int N51ICP_init();
 
 /**
- * @brief      Deinitializes the PGM interface and exits the target chip from ICP mode.
+ * @brief      Deinitializes the PGM interface.
  * 
  * @param[in] leave_reset_high  If set, the reset pin will not be released and will be left high after deinitializing the PGM interface.
 */
@@ -90,48 +91,35 @@ void N51ICP_outputf(const char *fmt, ...);
 /***
  * @brief     Set the program time for the N76E003.
  * 
- * This is the time that `N51ICP_write_flash()` will wait between bytes while writing to flash
- * (default: 25us)
- * @param time The time in microseconds
+ * @param delay_us The time to wait while programming (default: 25us)
+ * @param hold_us The time to wait after programming (default: 5us)
  */
-void N51ICP_set_program_time(uint32_t time_us);
+void N51ICP_set_program_time(uint32_t delay_us, uint32_t hold_us);
 
 /***
  * @brief     Set the page erase time for the N76E003.
  * 
- * This is the time that `N51ICP_page_erase()` will wait between pages while erasing flash
- * (default: 6000us)
- * 
- * @param time The time in microseconds
+ * @param delay_us The time to wait while erasing (default: 6000us)
+ * @param hold_us The time to wait after erasing (default: 100us)
 */
-void N51ICP_set_page_erase_time(uint32_t time_us);
+void N51ICP_set_page_erase_time(uint32_t delay_us, uint32_t hold_us);
 
 /***
  * @brief     Set the mass erase time for the N76E003.
  * 
- * This is the time that `N51ICP_mass_erase()` will wait during the erase
- * (default: 65000us)
- * 
- * @param time The time in microseconds
-*/
-void N51ICP_set_mass_erase_time(uint32_t time_us);
+ * @param delay_us The time to wait while erasing (default: 65000us)
+ * @param hold_us The time to wait after erasing (default: 1000us)
 
-/***
- * @brief     Set the post mass erase time for the N76E003.
- * 
- * This is the time that `N51ICP_mass_erase()` will wait after the erase
- * (default: 1000us)
- * 
- * @param time The time in microseconds
 */
-void N51ICP_set_post_mass_erase_time(uint32_t time_us);
+void N51ICP_set_mass_erase_time(uint32_t delay_us, uint32_t hold_us);
 
 /**
  * @brief      Puts the target chip into ICP mode.
  * 
  * @param do_reset If set, the reset sequence will be sent when performing ICP entry (recommended to set this to 1).
+ * @return         The detected device ID
 */
-void N51ICP_enter_icp_mode(uint8_t do_reset);
+uint32_t N51ICP_enter_icp_mode(uint8_t do_reset);
 
 /**
  * @brief      Takes the target chip out of ICP mode.

--- a/n51_icp.h
+++ b/n51_icp.h
@@ -91,7 +91,7 @@ void N51ICP_outputf(const char *fmt, ...);
  * @brief     Set the program time for the N76E003.
  * 
  * This is the time that `N51ICP_write_flash()` will wait between bytes while writing to flash
- * (default: 20us)
+ * (default: 25us)
  * @param time The time in microseconds
  */
 void N51ICP_set_program_time(uint32_t time_us);
@@ -105,6 +105,26 @@ void N51ICP_set_program_time(uint32_t time_us);
  * @param time The time in microseconds
 */
 void N51ICP_set_page_erase_time(uint32_t time_us);
+
+/***
+ * @brief     Set the mass erase time for the N76E003.
+ * 
+ * This is the time that `N51ICP_mass_erase()` will wait during the erase
+ * (default: 65000us)
+ * 
+ * @param time The time in microseconds
+*/
+void N51ICP_set_mass_erase_time(uint32_t time_us);
+
+/***
+ * @brief     Set the post mass erase time for the N76E003.
+ * 
+ * This is the time that `N51ICP_mass_erase()` will wait after the erase
+ * (default: 1000us)
+ * 
+ * @param time The time in microseconds
+*/
+void N51ICP_set_post_mass_erase_time(uint32_t time_us);
 
 /**
  * @brief      Puts the target chip into ICP mode.

--- a/n51_pgm.h
+++ b/n51_pgm.h
@@ -1,0 +1,93 @@
+/*
+ * nuvo51icp, an ICP flasher for the Nuvoton N76E003
+ * https://github.com/steve-m/N76E003-playground
+ *
+ * Copyright (c) 2021 Steve Markgraf <steve@steve-m.de>
+ * Copyright (c) 2023-2024 Nikita Lita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * These are the declarations for device-specific implementations of the PGM interface.
+*/
+#pragma once
+
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+
+#endif
+
+/**
+ * Initialize the PGM interface.
+ * 
+ * Sets the CLK and RST pins to output mode, sets DAT to Input mode, and sets the RST pin to low.
+ * 
+ * @return 0 on success, <0 on failure.
+ */
+int N51PGM_init(void);
+
+/**
+ * Deinitializes pgm interface.
+ * 
+ * Sets DAT and CLK pins to high-z, and terminates GPIO mode.
+ * NOTE: When implementing, make sure that this function is re-entrant!
+ * @param leave_reset_high If 1, the RST pin will be left high. If 0, the RST pin will be set to high-z.
+ */
+void N51PGM_deinit(uint8_t leave_reset_high);
+
+// Check if the PGM interface is initialized.
+uint8_t N51PGM_is_init();
+
+// Set the PGM data pin to the given value.
+void N51PGM_set_dat(uint8_t val);
+
+// Get the current value of the PGM data pin.
+uint8_t N51PGM_get_dat(void);
+
+// Set the PGM reset pin to the given value.
+void N51PGM_set_rst(uint8_t val);
+
+// Set the PGM clock pin to the given value.
+void N51PGM_set_clk(uint8_t val);
+
+// Sets the PGM trigger pin to the given value. (Optionally implemented, for fault injection purposes)
+void N51PGM_set_trigger(uint8_t val);
+
+// Sets the direction of the PGM data pin
+void N51PGM_dat_dir(uint8_t state);
+
+// Device-specific sleep function
+uint32_t N51PGM_usleep(uint32_t usec);
+
+// Device-specific get time function, in microseconds
+uint64_t N51PGM_get_time(void);
+
+// Device-specific print function
+void N51PGM_print(const char *msg);
+
+
+#ifdef __cplusplus
+}
+
+#endif

--- a/n51_pgm_NAE.c
+++ b/n51_pgm_NAE.c
@@ -1,0 +1,108 @@
+#include "n51_pgm.h"
+
+#include <asf.h>
+#include "board.h"
+#include "usart.h"
+#include "sysclk.h"
+#include "gpio.h"
+#include "ioport.h"
+#include "delay.h"
+
+static uint8_t initialized = 0;
+
+int N51PGM_init(void)
+{
+  /** TODO: Ensure that we are in AVR ISP Mode 
+   * i.e. CW_IOROUTE_ADDR[5] is set to |= 0x01
+  */
+	gpio_configure_pin(PIN_TARG_NRST_GPIO, (PIO_TYPE_PIO_OUTPUT_0 | PIO_DEFAULT));
+	gpio_configure_pin(PIN_PDIDTX_GPIO, PIN_PDIDTX_OUT_FLAGS);
+	gpio_configure_pin(PIN_PDIDRX_GPIO, PIN_PDIDRX_FLAGS);
+	gpio_configure_pin(PIN_PDIC_GPIO, PIN_PDIC_OUT_FLAGS);
+#ifdef PIN_PDIDWR_GPIO
+	gpio_set_pin_high(PIN_PDIDWR_GPIO);
+	gpio_set_pin_high(PIN_PDICWR_GPIO);
+#endif
+
+  gpio_set_pin_low(PIN_PDIDTX_GPIO);
+  gpio_set_pin_low(PIN_PDIC_GPIO);
+  gpio_set_pin_low(PIN_TARG_NRST_GPIO);
+  initialized = 1;
+  return 0;
+}
+
+void gpio_set_pin(uint32_t pin, int val){
+  if(val){
+    gpio_set_pin_high(pin);
+  }else{
+    gpio_set_pin_low(pin);
+  }
+}
+
+void N51PGM_set_dat(uint8_t val)
+{
+  gpio_set_pin(PIN_PDIDTX_GPIO, val);
+}
+
+uint8_t N51PGM_get_dat(void)
+{
+  return gpio_pin_is_high(PIN_PDIDRX_GPIO) ? 1 : 0;
+}
+
+void N51PGM_set_rst(uint8_t val)
+{
+  gpio_set_pin(PIN_TARG_NRST_GPIO, val);
+}
+
+void N51PGM_set_clk(uint8_t val)
+{
+  gpio_set_pin(PIN_PDIC_GPIO, val);
+}
+
+void N51PGM_set_trigger(uint8_t val)
+{
+  /** TODO: does nothing for now until I can figure out how to trigger GPIO4 from here**/
+}
+
+void N51PGM_dat_dir(uint8_t state)
+{
+  if(state){
+    gpio_configure_pin(PIN_PDIDTX_GPIO, PIN_PDIDTX_OUT_FLAGS);
+  }else{
+    gpio_configure_pin(PIN_PDIDTX_GPIO, PIN_PDIDTX_IN_FLAGS);
+  }
+}
+
+uint8_t N51PGM_is_init(){
+  return initialized;
+}
+
+void N51PGM_deinit(uint8_t leave_reset_high)
+{
+  /* Tristate all pins */
+	gpio_configure_pin(PIN_PDIC_GPIO, PIN_PDIC_IN_FLAGS);
+	gpio_configure_pin(PIN_PDIDRX_GPIO, PIN_PDIDRX_FLAGS);
+	gpio_configure_pin(PIN_PDIDTX_GPIO, PIN_PDIDTX_IN_FLAGS);
+
+  if (leave_reset_high) {
+    gpio_configure_pin(PIN_TARG_NRST_GPIO, (PIO_TYPE_PIO_OUTPUT_1 | PIO_DEFAULT));
+    gpio_set_pin_high(PIN_TARG_NRST_GPIO);
+  } else {
+    gpio_configure_pin(PIN_TARG_NRST_GPIO, (PIO_TYPE_PIO_INPUT | PIO_DEFAULT));
+  }
+  initialized = 0;
+}
+
+uint32_t N51PGM_usleep(uint32_t usec)
+{
+  delay_us(usec);
+  return usec;
+}
+
+// Not used by the ICP functions
+uint64_t N51PGM_get_time(void){
+  return 0;
+}
+
+void device_print(const char * msg){
+}

--- a/naeusb_usart.c
+++ b/naeusb_usart.c
@@ -50,6 +50,10 @@
 #include "V2Protocol.h"
 #endif
 
+#ifdef CW_PROG_NUVOICP
+#include "NuvoICPNewAE.h"
+#endif
+
 #define USART_WVREQ_INIT    0x0010
 #define USART_WVREQ_ENABLE  0x0011
 #define USART_WVREQ_DISABLE 0x0012
@@ -575,6 +579,12 @@ static void ctrl_usart_cb_data(void)
     }
 }
 
+#ifdef CW_PROG_NUVOICP
+void ctrl_n76e003_icp_program_void(void) {
+    NuvoICP_Protocol_Command();
+}
+#endif
+
 #ifdef CW_PROG_XMEGA
 void ctrl_xmega_program_void(void)
 {
@@ -729,6 +739,13 @@ bool usart_setup_out_received(void)
         udd_g_ctrlreq.callback = ctrl_spi1util;
         return true;
 #endif
+
+#ifdef CW_PROG_NUVOICP
+    case REQ_NU51_ICP_PROGRAM:
+        udd_g_ctrlreq.callback = ctrl_n76e003_icp_program_void;
+        return true;
+#endif
+
 #ifdef CW_PROG_XMEGA
     case REQ_XMEGA_PROGRAM:
         /*
@@ -782,6 +799,12 @@ bool usart_setup_in_received(void)
             udd_g_ctrlreq.payload = spi1util_data_buffer;
             udd_g_ctrlreq.payload_size = udd_g_ctrlreq.req.wLength;
             return true;
+        break;
+#endif
+
+#ifdef CW_PROG_NUVOICP
+    case REQ_NU51_ICP_PROGRAM:
+        return NuvoICP_Protocol_Command();
         break;
 #endif
 

--- a/naeusb_usart.h
+++ b/naeusb_usart.h
@@ -6,6 +6,8 @@
 #define REQ_XMEGA_PROGRAM 0x20
 #define REQ_AVR_PROGRAM 0x21
 #define REQ_CDC_SETTINGS_EN 0x31
+#define REQ_NU51_ICP_PROGRAM 0x40
+#define REQ_TEST_THING 0x69
 
 /* Target/Extra SPI Transfer */
 #define REQ_FPGASPI1_XFER 0x35


### PR DESCRIPTION
This PR adds support for ICP programming Nuvoton NuMicro 8051 chips. [It is adapted from my work here.](https://github.com/nikitalita/NUMicro-8051-prog)

The reason for ICP programming being used here is that, while Nuvoton chips do have an ISP protocol, it requires an LDROM to be loaded onto the chips first. The chips do not come pre-programmed with that and have to be loaded using an ICP tool, and if we have an ICP tool, we can just program the APROM directly. The LDROM also induces substantial latency when booting, which is not really suitable for our purposes, where the chips may be resetting thousands of times during glitch attempts. 

The USB wire protocol implementation here is largely derived from the XPROG one; I've tried to conform to the expectations there (putting all responses in the rambuf, putting all transmitted bulk data into the rambuf before programming, etc.)

Since this requires toggling nRST, this requires that AVR ISP be set first.

This should work for all the chips that are supported for the NuMicro CW308 target board, but I have only tested this with the N76E003, the MS51FB9AE, and the MS51FC0AE.

I have the chipwhisperer userland programmer implementation [up here](https://github.com/nikitalita/n76e003-cw-firmware), but I'm going to wait until this gets into naeusb before PRing it.

The reason this is a draft is because there are a couple of points that are marked as TODO:

- in `int N51PGM_init(void)()`, I want to be able to check to see if we are in AVRISP mode and fail if we aren't, but I do not know how to do that from the firmware. 
- I have an ICP function called `NuvoICP_Reentry_glitch()`. What this does is cause the configuration bytes to be loaded at consistent times when entering ICP mode, the idea being that we can potentially glitch a locked chip to boot into ICP mode in an unlocked state. It activates a trigger right before entry (vs. after, because the delay between entry and config load is like two microseconds) so that the config load process can be captured and glitched. However, I don't know how to toggle any of the TIO lines from the firmware, and I don't know if there's a way to manually trigger a glitch from the firmware. Any advice here?