### PR TITLE
Fix parity/stop/data bits being ignored in CDC SET_LINE_CODING

### DIFF
--- a/naeusb_usart.c
+++ b/naeusb_usart.c
@@ -889,47 +889,11 @@ void my_callback_config(uint8_t port, usb_cdc_line_coding_t * cfg)
 {
 	usart_driver *driver = get_nth_available_driver(port);
 
-    // if (driver->cdc_enabled && driver->cdc_settings_change) {
-        uint32_t baud = cfg->dwDTERate;
-
-        uint8_t stop_bits = ((uint32_t)cfg->bCharFormat) << 12;
-        uint8_t dbits = ((uint32_t)cfg->bDataBits - 5) << 6;
-        uint16_t parity_type = US_MR_PAR_NO;
-        switch(cfg->bParityType) {
-            case CDC_PAR_NONE:
-            parity_type = US_MR_PAR_NO;
-            break;
-            case CDC_PAR_ODD:
-            parity_type = US_MR_PAR_ODD;
-            break;
-            case CDC_PAR_EVEN:
-            parity_type = US_MR_PAR_EVEN;
-            break;
-            case CDC_PAR_MARK:
-            parity_type = US_MR_PAR_MARK;
-            break;
-            case CDC_PAR_SPACE:
-            parity_type = US_MR_PAR_SPACE;
-            break;
-            default:
-            return;
-        }
-
-
-		usart_enableIO(driver);
-        configure_usart(driver, baud, stop_bits, parity_type, dbits);
-        usart_enable_rx(driver->usart);
-        usart_enable_tx(driver->usart);
-
-        usart_enable_interrupt(driver->usart, UART_IER_RXRDY);
-		// if (!(usart_get_interrupt_mask(driver->usart) & UART_IER_RXRDY)) {
-		// 	usart_enable_rx(driver->usart);
-		// 	usart_enable_tx(driver->usart);
-
-		// 	usart_enable_interrupt(driver->usart, UART_IER_RXRDY);
-		// }
-		
-    // }
+	usart_enableIO(driver);
+	configure_usart(driver, cfg->dwDTERate, cfg->bCharFormat, cfg->bParityType, cfg->bDataBits);
+	usart_enable_rx(driver->usart);
+	usart_enable_tx(driver->usart);
+	usart_enable_interrupt(driver->usart, UART_IER_RXRDY);
 }
 
 // Handle USB OUT


### PR DESCRIPTION
Fix CDC SET_LINE_CODING ignoring parity, stop bits and data bits

my_callback_config() converted the CDC line coding values to US_MR
register values before passing them to configure_usart(), but
configure_usart() expects the raw CDC values (0=none, 1=odd, 2=even...)
and performs the same conversion again.

As a result US_MR_PAR_EVEN (0x0 << 9) became 0 and was re-mapped to
US_MR_PAR_NO, so even parity was silently dropped. The other parity
modes (0x200-0x800) were truncated by the uint8_t parameter and also
ended up as no parity. The same double conversion broke stop bits
(bCharFormat << 12 truncated to 0) and data bits ((bDataBits-5) << 6
hits the default case), which only worked by accident for the common
8N1 case.

Pass the raw line coding fields straight through to configure_usart(),
which already does the mapping.